### PR TITLE
version: use Sys.opaque_identity

### DIFF
--- a/mybuild.ml
+++ b/mybuild.ml
@@ -21,14 +21,23 @@ let git_describe ?git_dir ?(dirty="+\"$(git config user.name)@$(hostname)\"") ()
   with
     End_of_file -> version
 
+let ocaml_version =
+  let version major minor patch rest = (major, minor, patch, rest) in
+  try Some (Scanf.sscanf Sys.ocaml_version "%d.%d.%d%s@\n" version) with _ -> None
+
 let save ?(default="\"<unknown>\"") ?(identify=true) outfile =
   bracket (open_out outfile) close_out begin fun out ->
     let revision = try sprintf "%S" & git_describe ~dirty:"+M" () with _ -> default in
     let user = if identify then try cmd "git config user.name" with _ -> try Unix.getlogin () with _ -> ""  else "" in
     let host = if identify then try Unix.gethostname () with _ -> "" else "" in
-    Printf.fprintf out "let id = Sys.opaque_identity (%s)\n" revision;
-    Printf.fprintf out "let user = Sys.opaque_identity %S\n" user;
-    Printf.fprintf out "let host = Sys.opaque_identity %S\n" host;
+    let opaque =
+      match ocaml_version with
+      | Some (major, minor, _patch, _rest) when major = 4 && minor >= 3 || major > 4 -> "Sys.opaque_identity "
+      | _ -> ""
+    in
+    Printf.fprintf out "let id = %s(%s)\n" opaque revision;
+    Printf.fprintf out "let user = %s%S\n" opaque user;
+    Printf.fprintf out "let host = %s%S\n" opaque host;
   end
 
 end

--- a/mybuild.ml
+++ b/mybuild.ml
@@ -26,9 +26,9 @@ let save ?(default="\"<unknown>\"") ?(identify=true) outfile =
     let revision = try sprintf "%S" & git_describe ~dirty:"+M" () with _ -> default in
     let user = if identify then try cmd "git config user.name" with _ -> try Unix.getlogin () with _ -> ""  else "" in
     let host = if identify then try Unix.gethostname () with _ -> "" else "" in
-    Printf.fprintf out "let id = %s\n" revision;
-    Printf.fprintf out "let user = %S\n" user;
-    Printf.fprintf out "let host = %S\n" host;
+    Printf.fprintf out "let id = Sys.opaque_identity (%s)\n" revision;
+    Printf.fprintf out "let user = Sys.opaque_identity %S\n" user;
+    Printf.fprintf out "let host = Sys.opaque_identity %S\n" host;
   end
 
 end


### PR DESCRIPTION
Prevents inlining by the compiler, allowing for much faster rebuilds.